### PR TITLE
Running Vagrant, I got tired of nodejs recompiling every time I did a "vagrant up".  The commit message should be self-explanatory.  I don't have a solution for the "git clone" time yet though.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,12 @@ bash "compile_nodejs_source" do
     git clone https://github.com/joyent/node.git
     cd node
     git checkout #{node[:node][:version]}
-    ./configure && make && make install
+    previousnodeversion="$(cat /usr/local/share/node_version)"
+    currentnodeversion="$(git show -s --format=%H)"
+    if [ "$currentnodeversion" != "$previousnodeversion" ]; then
+      ./configure && make && make install
+      git show -s --format=%H > /usr/local/share/node_version
+    fi
   EOH
 end
 


### PR DESCRIPTION
Don't compile nodejs again if we'd be building the same version as is already installed

Whenever we build nodejs, we create a file
(/usr/local/share/node_version) that stores the sha1 hash of the current
commit.  Whenever the recipe is run, we compare the previous sha1 to the
current one.  If they are the same, we do nothing.
