### PR TITLE
npm modification

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,7 +59,7 @@ bash "install_npm" do
   user "root"
     cwd "/tmp/"
     code <<-EOH
-    curl http://npmjs.org/install.sh | clean=no sh
+    curl -k https://npmjs.org/install.sh | clean=no sh
     EOH
 end
 


### PR DESCRIPTION
npmjs.org redirects from http to https killing the cookbook with the following error:

[Thu, 16 Aug 2012 10:39:31 +0000] ERROR: bash[install_npm](/var/chef/cache/cookbooks/node/recipes/default.rb:46:in `from_file') had an error:
bash[install_npm](node::default line 46) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '2'

Quick fix.
