### PR TITLE
added explicit log_template_name to runit_service

### DIFF
--- a/providers/server.rb
+++ b/providers/server.rb
@@ -51,6 +51,7 @@ action :start do
     }
     runit_service "node-#{new_resource.name}" do
       template_name "nodejs"
+      log_template_name "nodejs"
       cookbook "node"
       options template_options
     end


### PR DESCRIPTION
Without it, we get FileNotFound errors on the log/run file
