### PR TITLE
Installing NPM Packages

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -14,9 +14,21 @@ Tested on ubuntu. Should work on other system with upstart.
 
 * node/revision : indicates which revision to install. Default is the latest ('HEAD'). Since node evolves very quickly and is not always that stable, you might want to set it to a stable version (for example 'v0.4.3')
 
+* `node[:node][:packages]` - An array of npm packages to be installed globally
+
 = USAGE:
 
 Include the node recipe to download, compile and install node along with npm.
+
+Optionally, you can add NPM packages by creating a packages array:
+
+```
+default_attributes({
+  node: {
+    packages: ['coffee-script', 'lineman']
+  }
+})
+```
 
 == defines:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,4 @@
 default[:node][:revision]      = "HEAD"
 default[:node][:repo_url]      = "https://github.com/joyent/node.git"
 default[:node][:user]          = "nodejs"
+default[:node][:packages]      = []

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,3 +57,5 @@ end
 user node[:node][:user] do
   system true
 end
+
+include_recipe 'node::packages'

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: node
+# Recipe:: packages
+#
+# Copyright 2011, Tikibooth Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node[:node][:packages].each do |package|
+  node_npm package do
+    action :install
+  end
+end


### PR DESCRIPTION
@digitalbutter please review
# Problem

Currently there is no way to add an NPM package to a role without creating a recipe/cookbook that calls `node_npm`.

While creating the recipe is easy enough, I thought it would be nice to not require that step. In my particular case I don't have a recipe for the role in question and didn't want to create one just to install a few packages.
# Solution

Added `node[:node][:packages]` attribute that will be used to install each package specified in the array.
## Usage

Add packages to the _default_attributes_ or __override_attributes_ in your role. Here's a sample role file:

```
run_list(
  ...
  ...
  'recipe[node]'
)

default_attributes({
  node: {
    packages: ['coffee-script', 'lineman']
  }
})
```

The new attribute is completely optional. It has been defaulted to `[]` to avoid any breaking changes with the current functionality.

Also, I've updated the README to include a description and usage for the new attribute.
