### PR TITLE
added the default action to node_npm

### DIFF
--- a/resources/npm.rb
+++ b/resources/npm.rb
@@ -1,4 +1,5 @@
 actions :install,:uninstall,:linstall,:luninstall
+default_action :install
 
 attribute :name, :kind_of => String, :name_attribute => true
 attribute :version, :default => nil


### PR DESCRIPTION
It must be reasonable to install the specified package when no action is specified.

``` ruby
node_npm "bower" # => installs bower (currently does nothing)
```
