### PR TITLE
added "name" setting to metadata.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "node"
 maintainer       "Tikibooth Limited"
 maintainer_email "devops@butter.com.hk"
 license          "Apache 2.0"


### PR DESCRIPTION
"name" setting is needed to prevent the following error on Vagrant 1.5.3 and vagrant-berkshelf 2.0.0.rc3:

> /home/jharai/.vagrant.d/gems/gems/ridley-3.0.0/lib/ridley/chef/cookbook.rb:44:in `from_path': The metadata at '/tmp/d20140416-24840-14l59qn' does not contain a  'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry. (Ridley::Errors::MissingNameAttribute)
